### PR TITLE
Return a partial item link if the full link is not available yet.

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -15,7 +15,7 @@ along with this library. If not, see <http://www.gnu.org/licenses/>.
 This file is part of LibItemCache.
 --]]
 
-local Lib = LibStub:NewLibrary('LibItemCache-1.1', 22)
+local Lib = LibStub:NewLibrary('LibItemCache-1.1', 23)
 if not Lib then
 	return
 end
@@ -281,8 +281,9 @@ function Lib:RestorePetLink(partial)
 end
 
 function Lib:RestoreItemLink(partial)
-	local _, link, quality = GetItemInfo('item:' .. partial)
-	return link, GetItemIcon(link), quality
+	partial = 'item:' .. partial
+	local _, link, quality = GetItemInfo(partial)
+	return link or partial, GetItemIcon(link), quality
 end
 
 


### PR DESCRIPTION
When an item is not in the games local cache, GetItemInfo fails to
return any information until the information has been asynchroniously
retrieved from the server.

Instead of returning nil, LibItemCache-1.1 will now return a partial
item link, which will allow an addon using the library to detect this
situation (ie. by checking if link is set but icon is still empty)
and schedule a refresh of this information once the game has retrieved
this information from the server (ie. GET_ITEM_INFO_RECEIVED event).

Otherwise, addons are not able to determine if a slot is empty, or
still missing item information from the server.
